### PR TITLE
Fix client parsing

### DIFF
--- a/Sources/MCP/Base/Transports.swift
+++ b/Sources/MCP/Base/Transports.swift
@@ -396,13 +396,7 @@ public actor StdioTransport: Transport {
                         if !receiveContinuationResumed {
                             receiveContinuationResumed = true
                             if let error = error {
-                                if let nwError = error as? NWError {
-                                    continuation.resume(throwing: MCP.Error.transportError(nwError))
-                                } else {
-                                    continuation.resume(
-                                        throwing: MCP.Error.internalError("Receive error: \(error)")
-                                    )
-                                }
+                                continuation.resume(throwing: MCP.Error.transportError(error))
                             } else if let content = content {
                                 continuation.resume(returning: content)
                             } else {

--- a/Sources/MCP/Base/Value.swift
+++ b/Sources/MCP/Base/Value.swift
@@ -400,16 +400,3 @@ extension String {
         }
     }
 }
-
-// MARK: - Decode specific type from Value
-
-extension JSONDecoder {
-    public func decode<T: Decodable>(_ type: T.Type, from value: Value) throws -> T {
-        guard let data = try? JSONEncoder().encode(value) else {
-            throw DecodingError.dataCorrupted(
-                DecodingError.Context(codingPath: [], debugDescription: "Failed to encode value"))
-        }
-
-        return try self.decode(T.self, from: data)
-    }
-}

--- a/Sources/MCP/Base/Value.swift
+++ b/Sources/MCP/Base/Value.swift
@@ -401,15 +401,15 @@ extension String {
     }
 }
 
-
-
 // MARK: - Decode specific type from Value
 
-public extension JSONDecoder {
-  func decode<T: Decodable>(_ type: T.Type, from value: Value) throws -> T {
-    guard let data = try? JSONEncoder().encode(value) else {
-      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Failed to encode value"))
-    }    
-    return try self.decode(T.self, from: data)
-  }
+extension JSONDecoder {
+    public func decode<T: Decodable>(_ type: T.Type, from value: Value) throws -> T {
+        guard let data = try? JSONEncoder().encode(value) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "Failed to encode value"))
+        }
+
+        return try self.decode(T.self, from: data)
+    }
 }

--- a/Sources/MCP/Base/Value.swift
+++ b/Sources/MCP/Base/Value.swift
@@ -400,3 +400,16 @@ extension String {
         }
     }
 }
+
+
+
+// MARK: - Decode specific type from Value
+
+public extension JSONDecoder {
+  func decode<T: Decodable>(_ type: T.Type, from value: Value) throws -> T {
+    guard let data = try? JSONEncoder().encode(value) else {
+      throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Failed to encode value"))
+    }    
+    return try self.decode(T.self, from: data)
+  }
+}

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -106,7 +106,8 @@ public actor Client {
                     if let typedValue = value as? T {
                         request.continuation.resume(returning: typedValue)
                     } else if let value = value as? Value,
-                        let decoded = try? JSONDecoder().decode(T.self, from: value)
+                        let data = try? JSONEncoder().encode(value),
+                        let decoded = try? JSONDecoder().decode(T.self, from: data)
                     {
                         request.continuation.resume(returning: decoded)
                     } else {

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -87,8 +87,15 @@ public actor Client {
     /// The task for the message handling loop
     private var task: Task<Void, Never>?
 
+    /// An error indicating a type mismatch when decoding a pending request
     private struct TypeMismatchError: Swift.Error {}
 
+    /// A pending request with a continuation for the result
+    private struct PendingRequest<T> {
+        let continuation: CheckedContinuation<T, Swift.Error>
+    }
+
+    /// A type-erased pending request
     private struct AnyPendingRequest {
         private let _resume: (Result<Any, Swift.Error>) -> Void
 
@@ -119,10 +126,6 @@ public actor Client {
         }
     }
 
-    /// A pending request with a continuation for the result
-    private struct PendingRequest<T> {
-        let continuation: CheckedContinuation<T, Swift.Error>
-    }
     /// A dictionary of type-erased pending requests, keyed by request ID
     private var pendingRequests: [ID: AnyPendingRequest] = [:]
 

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -87,12 +87,44 @@ public actor Client {
     /// The task for the message handling loop
     private var task: Task<Void, Never>?
 
+
+  private struct TypeMismatchError: Swift.Error {}
+
+  private struct AnyPendingRequest {
+    private let _resume: (Result<Any, Swift.Error>) -> Void
+      
+    init<T: Sendable & Decodable>(_ request: PendingRequest<T>) {
+          _resume = { result in
+              switch result {
+              case .success(let value):
+                if let typedValue = value as? T {
+                  request.continuation.resume(returning: typedValue)
+                } else if let value = value as? Value,
+                          let decoded = try? JSONDecoder().decode(T.self, from: value) {
+                  request.continuation.resume(returning: decoded)
+                } else {
+                  request.continuation.resume(throwing: TypeMismatchError())
+                }
+              case .failure(let error):
+                request.continuation.resume(throwing: error)
+              }
+          }
+      }
+    func resume(returning value: Any) {
+      _resume(.success(value))
+    }
+    
+    func resume(throwing error: Swift.Error) {
+      _resume(.failure(error))
+    }
+  }
+
     /// A pending request with a continuation for the result
     private struct PendingRequest<T> {
         let continuation: CheckedContinuation<T, Swift.Error>
     }
     /// A dictionary of type-erased pending requests, keyed by request ID
-    private var pendingRequests: [ID: Any] = [:]
+    private var pendingRequests: [ID: AnyPendingRequest] = [:]
 
     public init(
         name: String,
@@ -129,8 +161,8 @@ public actor Client {
 
                         // Attempt to decode string data as AnyResponse or AnyMessage
                         let decoder = JSONDecoder()
-                        if let response = try? decoder.decode(AnyResponse.self, from: data) {
-                            await handleResponse(response, for: response)
+                      if let response = try? decoder.decode(AnyResponse.self, from: data), let request = pendingRequests[response.id] {
+                            await handleResponse(response, for: request)
                         } else if let message = try? decoder.decode(AnyMessage.self, from: data) {
                             await handleMessage(message)
                         } else {
@@ -220,12 +252,12 @@ public actor Client {
         }
     }
 
-    private func addPendingRequest<T>(
+  private func addPendingRequest<T: Sendable & Decodable>(
         id: ID,
         continuation: CheckedContinuation<T, Swift.Error>,
         type: T.Type
     ) {
-        pendingRequests[id] = PendingRequest(continuation: continuation)
+        pendingRequests[id] = AnyPendingRequest(PendingRequest(continuation: continuation))
     }
 
     private func removePendingRequest(id: ID) {
@@ -320,21 +352,19 @@ public actor Client {
 
     // MARK: -
 
-    private func handleResponse(_ response: Response<AnyMethod>, for request: Any) async {
+    private func handleResponse(_ response: Response<AnyMethod>, for request: AnyPendingRequest) async {
         await logger?.debug(
             "Processing response",
             metadata: ["id": "\(response.id)"])
 
         // We know this cast is safe because we only store PendingRequest values
-        guard let typedRequest = request as? PendingRequest<Any> else { return }
-
-        switch response.result {
-        case .success(let value):
-            typedRequest.continuation.resume(returning: value)
-        case .failure(let error):
-            typedRequest.continuation.resume(throwing: error)
-        }
-
+      
+      switch response.result {
+      case .success(let value):
+        request.resume(returning: value)
+      case .failure(let error):
+        request.resume(throwing: error)
+      }
         removePendingRequest(id: response.id)
     }
 

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -190,11 +190,7 @@ public actor Client {
     public func disconnect() async {
         // Cancel all pending requests
         for (id, request) in pendingRequests {
-            // We know this cast is safe because we only store PendingRequest values
-            if let typedRequest = request as? PendingRequest<Any> {
-                typedRequest.continuation.resume(
-                    throwing: Error.internalError("Client disconnected"))
-            }
+            request.resume(throwing: Error.internalError("Client disconnected"))
             pendingRequests.removeValue(forKey: id)
         }
 

--- a/Tests/MCPTests/RoundtripTests.swift
+++ b/Tests/MCPTests/RoundtripTests.swift
@@ -41,27 +41,27 @@ struct RoundtripTests {
         try await server.start(transport: serverTransport)
         try await client.connect(transport: clientTransport)
 
-        // let initTask = Task {
-        //     let result = try await client.initialize()
+        let initTask = Task {
+            let result = try await client.initialize()
 
-        //     #expect(result.serverInfo.name == "TestServer")
-        //     #expect(result.serverInfo.version == "1.0.0")
-        //     #expect(result.capabilities.prompts != nil)
-        //     #expect(result.capabilities.tools != nil)
-        //     #expect(result.protocolVersion == Version.latest)
-        // }
-        // try await withThrowingTaskGroup(of: Void.self) { group in
-        //     group.addTask {
-        //         try await Task.sleep(for: .seconds(1))
-        //         initTask.cancel()
-        //         throw CancellationError()
-        //     }
-        //     group.addTask {
-        //         try await initTask.value
-        //     }
-        //     try await group.next()
-        //     group.cancelAll()
-        // }
+            #expect(result.serverInfo.name == "TestServer")
+            #expect(result.serverInfo.version == "1.0.0")
+            #expect(result.capabilities.prompts != nil)
+            #expect(result.capabilities.tools != nil)
+            #expect(result.protocolVersion == Version.latest)
+        }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await Task.sleep(for: .seconds(1))
+                initTask.cancel()
+                throw CancellationError()
+            }
+            group.addTask {
+                try await initTask.value
+            }
+            try await group.next()
+            group.cancelAll()
+        }
 
         await server.stop()
         await client.disconnect()

--- a/Tests/MCPTests/RoundtripTests.swift
+++ b/Tests/MCPTests/RoundtripTests.swift
@@ -8,10 +8,9 @@ import Testing
 @Suite("Roundtrip Tests")
 struct RoundtripTests {
     @Test(
-        "Initialize roundtrip",
         .timeLimit(.minutes(1))
     )
-    func testInitializeRoundtrip() async throws {
+    func testRoundtrip() async throws {
         let (clientToServerRead, clientToServerWrite) = try FileDescriptor.pipe()
         let (serverToClientRead, serverToClientWrite) = try FileDescriptor.pipe()
 
@@ -36,6 +35,32 @@ struct RoundtripTests {
             version: "1.0.0",
             capabilities: .init(prompts: .init(), tools: .init())
         )
+        await server.withMethodHandler(ListTools.self) { _ in
+            return ListTools.Result(tools: [
+                Tool(
+                    name: "add",
+                    description: "Adds two numbers together",
+                    inputSchema: [
+                        "a": ["type": "integer", "description": "The first number"],
+                        "a": ["type": "integer", "description": "The second number"],
+                    ])
+            ])
+        }
+        await server.withMethodHandler(CallTool.self) { request in
+            guard request.name == "add" else {
+                return CallTool.Result(content: [.text("Invalid tool name")], isError: true)
+            }
+
+            guard let a = request.arguments?["a"]?.intValue,
+                  let b = request.arguments?["b"]?.intValue
+            else {
+                return CallTool.Result(
+                    content: [.text("Did not receive valid arguments")], isError: true)
+            }
+
+            return CallTool.Result(content: [.text("\(a + b)")], isError: false)
+        }
+
         let client = Client(name: "TestClient", version: "1.0")
 
         try await server.start(transport: serverTransport)
@@ -58,6 +83,31 @@ struct RoundtripTests {
             }
             group.addTask {
                 try await initTask.value
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+
+        let listToolsTask = Task {
+            let result = try await client.listTools()
+            #expect(result.count == 1)
+            #expect(result[0].name == "add")
+        }
+
+        let callToolTask = Task {
+            let result = try await client.callTool(name: "add", arguments: ["a": 1, "b": 2])
+            #expect(result.isError == false)
+            #expect(result.content == [.text("3")])
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await Task.sleep(for: .seconds(1))
+                listToolsTask.cancel()
+                throw CancellationError()
+            }
+            group.addTask {
+                try await callToolTask.value
             }
             try await group.next()
             group.cancelAll()


### PR DESCRIPTION
This addressed issue #7, tldr looks like client had no way of parsing response due to 

1. Response arriving as a `Value` instead of strong type associated with request
2. Request casting to `<Any>` seem to constantly fail for me, introducing type-erased wrapper seem to fix it for me

There is a good chance I am not aware of the original thinking and missing something obvious to make it work 🙂 

## Original Issue Description:

I will prephrase my question by saying I am not sure at all that any of my findings are accurate. 
_I think_ I am seeing consistent failure of the client to handle responses due to 2 issues:

First of all it appears that we are passing response twice under

https://github.com/loopwork-ai/mcp-swift-sdk/blob/main/Sources/MCP/Client/Client.swift#L132-L133

Where instead we should be getting appropriate request from pandingRequests like so

```swift
if let response = try? decoder.decode(AnyResponse.self, from: data), let request = pendingRequests[response.id] {
  await handleResponse(response, for: request)
} ... 
``` 

Even fixing that locally downcast here https://github.com/loopwork-ai/mcp-swift-sdk/blob/main/Sources/MCP/Client/Client.swift#L329 fails 

```swift
guard let typedRequest = request as? PendingRequest<Any> else { return }
```

Not sure if there is a way to tell Swift "don't worry about generic the original value was created with", it seem to consistently fail. Specifically I am debugging initialize sequence and so when I fix passing pending request, `$ po request` prints `MCP.Client.PendingRequest<MCP.Initialize.Result>)` , tho `guard let typedRequest = request as? PendingRequest<Any> else { return }` fails

Any ideas if I am holding it wrong? or we might need to store type-erased pending requests instead of Any?