### PR TITLE
Remove nonstandard `read` and `list` capabilities for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ let server = Server(
     name: "MyServer", 
     version: "1.0.0",
     capabilities: .init(
+        prompts: .init(),
         resources: .init(
-            list: true,
-            read: true,
             subscribe: true
-        )
+        ),
+        tools: .init()
     )
 )
 

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -313,7 +313,7 @@ public actor Client {
     // MARK: - Resources
 
     public func readResource(uri: String) async throws -> [Resource.Content] {
-        _ = try checkCapability(\.resources?.read, "Resource reading")
+        _ = try checkCapability(\.resources, "Resources")
         let request = ReadResource.request(.init(uri: uri))
         let result = try await send(request)
         return result.contents
@@ -322,7 +322,7 @@ public actor Client {
     public func listResources(cursor: String? = nil) async throws -> (
         resources: [Resource], nextCursor: String?
     ) {
-        _ = try checkCapability(\.resources?.list, "Resource listing")
+        _ = try checkCapability(\.resources, "Resources")
         let request = ListResources.request(.init(cursor: cursor))
         let result = try await send(request)
         return (resources: result.resources, nextCursor: result.nextCursor)

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -44,23 +44,15 @@ public actor Server {
     public struct Capabilities: Hashable, Codable, Sendable {
         /// Resources capabilities
         public struct Resources: Hashable, Codable, Sendable {
-            /// Whether the list of resources has changed
-            public var list: Bool?
-            /// Whether the resource can be read
-            public var read: Bool?
             /// Whether the resource can be subscribed to
             public var subscribe: Bool?
             /// Whether the list of resources has changed
             public var listChanged: Bool?
 
             public init(
-                list: Bool? = nil,
-                read: Bool? = nil,
                 subscribe: Bool? = nil,
                 listChanged: Bool? = nil
             ) {
-                self.list = list
-                self.read = read
                 self.subscribe = subscribe
                 self.listChanged = listChanged
             }


### PR DESCRIPTION
Resolves #14 

1. The [current implementation of `Server.Capabilities.Resources`](https://github.com/loopwork-ai/mcp-swift-sdk/blob/dccaa3a411cfc2b028d390cdecd2c8acbdc65746/Sources/MCP/Server/Server.swift#L44-L67) defines nonstandard `read` and `list` capabilities.
2. The [current implementation of `Client.listResources`](https://github.com/loopwork-ai/mcp-swift-sdk/blob/dccaa3a411cfc2b028d390cdecd2c8acbdc65746/Sources/MCP/Client/Client.swift#L325) and [`Client.readResources`](https://github.com/loopwork-ai/mcp-swift-sdk/blob/dccaa3a411cfc2b028d390cdecd2c8acbdc65746/Sources/MCP/Client/Client.swift#L316) include a specific check for that capability. This causes requests to fail because servers won't include that capability.

This PR removes these nonstandard capabilities from the `Server.Capabilities` type and updates the checks in `Client` accordingly.