### PR TITLE
Revert "Update capabilities to be expressible by Boolean literals"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ let server = Server(
     name: "MyServer", 
     version: "1.0.0",
     capabilities: .init(
-        prompts: true,
-        resources: true,
-        tools: true
+        prompts: .init(),
+        resources: .init(
+            subscribe: true
+        ),
+        tools: .init()
     )
 )
 

--- a/Sources/MCP/Client/Client.swift
+++ b/Sources/MCP/Client/Client.swift
@@ -423,17 +423,3 @@ public actor Client {
         return value
     }
 }
-
-// MARK: - ExpressibleByBooleanLiteral
-
-extension Client.Capabilities.Roots: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self.init()
-    }
-}
-
-extension Client.Capabilities.Sampling: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self.init()
-    }
-}

--- a/Sources/MCP/Server/Server.swift
+++ b/Sources/MCP/Server/Server.swift
@@ -408,29 +408,3 @@ public actor Server {
         self.isInitialized = true
     }
 }
-
-// MARK: - ExpressibleByBooleanLiteral
-
-extension Server.Capabilities.Logging: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self.init()
-    }
-}
-
-extension Server.Capabilities.Prompts: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self.init()
-    }
-}
-
-extension Server.Capabilities.Resources: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self.init()
-    }
-}
-
-extension Server.Capabilities.Tools: ExpressibleByBooleanLiteral {
-    public init(booleanLiteral value: Bool) {
-        self.init()
-    }
-}

--- a/Tests/MCPTests/RoundtripTests.swift
+++ b/Tests/MCPTests/RoundtripTests.swift
@@ -34,9 +34,9 @@ struct RoundtripTests {
             name: "TestServer",
             version: "1.0.0",
             capabilities: .init(
-                prompts: true,
-                resources: true,
-                tools: true
+                prompts: .init(),
+                resources: .init(),
+                tools: .init()
             )
         )
         await server.withMethodHandler(ListTools.self) { _ in


### PR DESCRIPTION
Reverts loopwork-ai/mcp-swift-sdk#16

Neglected to appreciate that passing `false` has the same behavior as `true`. We could `fatalError` in that case, but that feels bad.