### PR TITLE
Add unit test to check that AnyRequest handles missing parameters

### DIFF
--- a/Tests/MCPTests/RequestTests.swift
+++ b/Tests/MCPTests/RequestTests.swift
@@ -260,4 +260,34 @@ struct RequestTests {
             from: withCursor.data(using: .utf8)!)
         #expect(decodedWithCursor.params.cursor == "next-page")
     }
+
+    @Test("AnyRequest parameters request decoding - without params")
+    func testAnyRequestParametersRequestDecodingWithoutParams() throws {
+        // Test decoding when params field is missing
+        let jsonString = """
+            {"jsonrpc":"2.0","id":1,"method":"ping"}
+            """
+        let data = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(AnyRequest.self, from: data)
+
+        #expect(decoded.id == 1)
+        #expect(decoded.method == Ping.name)
+    }
+
+    @Test("AnyRequest parameters request decoding - with null params")
+    func testAnyRequestParametersRequestDecodingWithNullParams() throws {
+        // Test decoding when params field is null
+        let jsonString = """
+            {"jsonrpc":"2.0","id":1,"method":"ping","params":null}
+            """
+        let data = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Request<Ping>.self, from: data)
+
+        #expect(decoded.id == 1)
+        #expect(decoded.method == Ping.name)
+    }
 }


### PR DESCRIPTION
**First part of the issue:**

Here's a unit test that shows part of the issue. When a new message comes in, the JSON is first decoded into an AnyRequest in [Server's input stream handler](https://github.com/loopwork-ai/mcp-swift-sdk/blob/main/Sources/MCP/Server/Server.swift#L187), and then is decoded to the concrete Request type in [`TypedRequestHandler`](https://github.com/loopwork-ai/mcp-swift-sdk/blob/main/Sources/MCP/Base/Messages.swift#L144).

This means that the AnyRequest type must also be able to handle missing `params`.

These screenshots show the issue. First screenshot shows the list tools request arrive with `{"method":"tools/list","jsonrpc":"2.0","id":1}` trying to decode into an AnyRequest

![CleanShot 2025-03-19 at 00 13 43@2x](https://github.com/user-attachments/assets/e31edf7f-df66-43ba-89ba-32939bbd419e)

second screenshot shows the decoding fail because `M.Parameters.self` is `Value` not `Empty`

![CleanShot 2025-03-19 at 00 17 34@2x](https://github.com/user-attachments/assets/22be5791-bd71-4998-8a28-a7ef8bc77a8d)


**Second part of the issue:**

I believe this wouldn't fix it entirely, as the parameters from the `AnyRequest` are re-encoded and decoded in `callAsFunction` of the `TypedRequestHandler`. This decodes into `M.Parameters.self` directly, so the `NotRequired` handling in `Request.init(from decoder:)` doesn't get called here, and instead the decoding would fail immediately.
